### PR TITLE
Add unit tests and CI for core services

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,21 @@
+name: Tests
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install pytest pytest-asyncio aiohttp
+      - name: Run tests
+        run: pytest

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+testpaths = tests

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,19 @@
+import sys
+import types
+
+# Stub dotenv.load_dotenv so configuration imports succeed without the package
+sys.modules.setdefault("dotenv", types.SimpleNamespace(load_dotenv=lambda *args, **kwargs: None))
+
+# Provide minimal aiohttp stubs used by service modules
+class _ClientTimeout:
+    def __init__(self, total=None, connect=None):
+        self.total = total
+        self.connect = connect
+
+class _ClientSession:
+    async def close(self):
+        pass
+
+sys.modules.setdefault(
+    "aiohttp", types.SimpleNamespace(ClientSession=_ClientSession, ClientTimeout=_ClientTimeout)
+)

--- a/tests/test_event_bus.py
+++ b/tests/test_event_bus.py
@@ -1,0 +1,28 @@
+import asyncio
+from topstepx_backend.core.event_bus import EventBus
+
+
+def test_event_bus_publish_subscribe():
+    async def run():
+        bus = EventBus()
+        await bus.start()
+        sub = await bus.subscribe("test.topic")
+        await bus.publish("test.topic", {"value": 1})
+        topic, payload = await asyncio.wait_for(sub.__anext__(), timeout=1)
+        assert topic == "test.topic"
+        assert payload == {"value": 1}
+        await bus.stop()
+    asyncio.run(run())
+
+
+def test_event_bus_wildcard_subscription():
+    async def run():
+        bus = EventBus()
+        await bus.start()
+        sub = await bus.subscribe("market.*")
+        await bus.publish("market.update", 42)
+        topic, payload = await asyncio.wait_for(sub.__anext__(), timeout=1)
+        assert topic == "market.update"
+        assert payload == 42
+        await bus.stop()
+    asyncio.run(run())

--- a/tests/test_order_service.py
+++ b/tests/test_order_service.py
@@ -1,0 +1,85 @@
+import asyncio
+
+from topstepx_backend.core.event_bus import EventBus
+from topstepx_backend.services.order_service import OrderService
+from topstepx_backend.config.settings import TopstepConfig
+
+
+class DummyAuthManager:
+    def get_token(self):
+        return "token"
+
+
+class DummyRateLimiter:
+    async def acquire(self, endpoint: str = "", tokens: int = 1, raise_on_limit: bool = False):
+        return True
+
+
+class FakeResponse:
+    def __init__(self):
+        self.status = 200
+
+    async def json(self):
+        return {"accounts": [{"id": 1, "name": "acct", "canTrade": True, "isVisible": True}]}
+
+    async def text(self):
+        return ""
+
+
+class FakeRequestContext:
+    def __init__(self, response):
+        self.response = response
+
+    def __await__(self):
+        async def _():
+            return self.response
+        return _().__await__()
+
+    async def __aenter__(self):
+        return self.response
+
+    async def __aexit__(self, exc_type, exc, tb):
+        pass
+
+
+class FakeSession:
+    def __init__(self, *args, **kwargs):
+        self.closed = False
+
+    def post(self, *args, **kwargs):
+        return FakeRequestContext(FakeResponse())
+
+    async def close(self):
+        self.closed = True
+
+
+def test_order_service_start_stop():
+    async def run():
+        import aiohttp
+        aiohttp.ClientSession = FakeSession
+        bus = EventBus()
+        await bus.start()
+        cfg = TopstepConfig(
+            username="user",
+            api_key="a" * 32,
+            account_id=1,
+            account_name="acct",
+            projectx_base_url="https://api.example.com",
+            projectx_user_hub_url="https://rtc.example.com/hubs/user",
+            projectx_market_hub_url="https://rtc.example.com/hubs/market",
+            base_url="https://api.example.com",
+            user_hub_url="https://rtc.example.com/hubs/user",
+            market_hub_url="https://rtc.example.com/hubs/market",
+            database_path=":memory:",
+            log_level="INFO",
+            environment="development",
+            live_mode=True,
+        )
+        auth = DummyAuthManager()
+        rate = DummyRateLimiter()
+        service = OrderService(bus, auth, cfg, rate)
+        await service.start()
+        assert service._running is True
+        await service.stop()
+        await bus.stop()
+    asyncio.run(run())

--- a/tests/test_timeframe_aggregator.py
+++ b/tests/test_timeframe_aggregator.py
@@ -1,0 +1,61 @@
+import asyncio
+from datetime import datetime, timedelta, timezone
+
+from topstepx_backend.core.event_bus import EventBus
+from topstepx_backend.data.timeframe_aggregator import TimeframeAggregator
+from topstepx_backend.data.types import Bar
+from topstepx_backend.config.settings import TopstepConfig
+
+
+def make_config():
+    return TopstepConfig(
+        username="user",
+        api_key="a" * 32,
+        account_id=1,
+        account_name="acct",
+        projectx_base_url="https://api.example.com",
+        projectx_user_hub_url="https://rtc.example.com/hubs/user",
+        projectx_market_hub_url="https://rtc.example.com/hubs/market",
+        base_url="https://api.example.com",
+        user_hub_url="https://rtc.example.com/hubs/user",
+        market_hub_url="https://rtc.example.com/hubs/market",
+        database_path=":memory:",
+        log_level="INFO",
+        environment="development",
+        live_mode=True,
+    )
+
+
+def test_timeframe_aggregator_handles_boundary():
+    async def run():
+        bus = EventBus()
+        await bus.start()
+        cfg = make_config()
+        agg = TimeframeAggregator(cfg, event_bus=bus)
+        sub = await bus.subscribe("market.bar.ES_5m")
+        start = datetime(2024, 1, 1, tzinfo=timezone.utc)
+        for i in range(5):
+            bar = Bar(
+                timestamp=start + timedelta(minutes=i),
+                contract_id="ES",
+                timeframe="1m",
+                open=1.0,
+                high=1.0 + i,
+                low=1.0,
+                close=1.0 + i,
+                volume=1,
+                source="live",
+            )
+            await agg._update_aggregation(bar, "5m")
+        boundary_ts = start + timedelta(minutes=5)
+        await agg._handle_boundary_close("5m", boundary_ts)
+        topic, payload = await asyncio.wait_for(sub.__anext__(), timeout=1)
+        assert topic == "market.bar.ES_5m"
+        assert payload["timeframe"] == "5m"
+        assert payload["contract_id"] == "ES"
+        assert payload["open"] == 1.0
+        assert payload["high"] == 1.0 + 4
+        assert payload["close"] == 1.0 + 4
+        assert payload["volume"] == 5
+        await bus.stop()
+    asyncio.run(run())


### PR DESCRIPTION
## Summary
- add pytest configuration and GitHub Actions workflow
- create tests for EventBus and TimeframeAggregator
- test OrderService startup with mocked network session

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ae525f36e0833080b3b7873c38c1a1