### PR TITLE
Load default contracts from configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,13 @@
+# CHILLLY
+
+This project contains backend services for managing market subscriptions and trading operations.
+
+## Default Contract Subscriptions
+
+Operators can specify which contracts are subscribed to on startup by setting the `DEFAULT_CONTRACTS` environment variable or by providing it in an `.env` file. The value should be a comma-separated list of full contract identifiers. Example:
+
+```
+DEFAULT_CONTRACTS=CON.F.US.EP.U25,CON.F.US.ENQ.U25
+```
+
+When no prior subscription state exists, these contracts are loaded as the initial active subscriptions.

--- a/topstepx_backend/config/settings.py
+++ b/topstepx_backend/config/settings.py
@@ -1,7 +1,7 @@
 import os
 import re
-from typing import Optional
-from dataclasses import dataclass
+from typing import Optional, List
+from dataclasses import dataclass, field
 from dotenv import load_dotenv
 from urllib.parse import urlparse
 
@@ -27,6 +27,7 @@ class TopstepConfig:
     log_level: str
     environment: str
     live_mode: bool = True  # Live mode by default
+    default_contracts: List[str] = field(default_factory=list)  # Initial contract subscriptions
 
     @classmethod
     def from_env(cls, env_file: Optional[str] = None) -> "TopstepConfig":
@@ -66,6 +67,11 @@ class TopstepConfig:
             log_level=os.getenv("LOG_LEVEL", "INFO"),
             environment=os.getenv("ENVIRONMENT", "development"),
             live_mode=os.getenv("LIVE_MODE", "true").lower() == "true",
+            default_contracts=[
+                c.strip()
+                for c in os.getenv("DEFAULT_CONTRACTS", "").split(",")
+                if c.strip()
+            ],
         )
 
     def validate(self) -> bool:

--- a/topstepx_backend/services/market_subscription_service.py
+++ b/topstepx_backend/services/market_subscription_service.py
@@ -2,6 +2,7 @@
 
 Provides runtime management of which contracts are being polled by PollingBarService.
 Persists subscription state and integrates with EventBus for real-time updates.
+Initial subscriptions are loaded from configuration.
 """
 
 import asyncio
@@ -133,12 +134,12 @@ class MarketSubscriptionService:
             else:
                 self._state = self._create_default_state()
                 await self._save_state()
-    
+
     def _create_default_state(self) -> MarketSubscriptionState:
-        """Create default subscription state with full contractIds."""
+        """Create default subscription state from configuration."""
         return MarketSubscriptionState(
-            active_contracts={"CON.F.US.EP.U25", "CON.F.US.ENQ.U25", "CON.F.US.ERW.U25", "CON.F.US.ETF.U25"},  # Default full contractIds
-            last_updated=utc_now()
+            active_contracts=set(self.config.default_contracts),
+            last_updated=utc_now(),
         )
     
     async def _save_state(self):


### PR DESCRIPTION
## Summary
- remove hardcoded contract list in `MarketSubscriptionService`
- load default subscriptions from `DEFAULT_CONTRACTS` env var
- document how to configure startup contracts

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ae525f5e9c8330a68d3d252fa67d67