### PR TITLE
Add market subscription service to orchestrator

### DIFF
--- a/topstepx_backend/orchestrator.py
+++ b/topstepx_backend/orchestrator.py
@@ -100,6 +100,8 @@ class TopstepXOrchestrator:
         self.polling_bar_service: Optional[PollingBarService] = None
         self.historical_fetcher: Optional[HistoricalFetcher] = None
         self.timeframe_aggregator: Optional[TimeframeAggregator] = None
+        # Coordinates dynamic market data subscriptions
+        self.market_subscription_service: Optional[MarketSubscriptionService] = None
         self.series_cache_service: Optional[SeriesCacheService] = None
 
         # Network services


### PR DESCRIPTION
## Summary
- add `market_subscription_service` attribute to orchestrator initialization
- document purpose of market subscription service
- ensure startup order references new service

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ae57c8cac0833099d51995d708ccbd