### PR TITLE
Use contract validator in MarketSubscriptionService

### DIFF
--- a/topstepx_backend/services/market_subscription_service.py
+++ b/topstepx_backend/services/market_subscription_service.py
@@ -9,13 +9,17 @@ import asyncio
 import json
 import logging
 from pathlib import Path
-from typing import Set, Dict, Any, Optional
+from typing import Set, Dict, Any, Optional, TYPE_CHECKING
 from dataclasses import dataclass
 from datetime import datetime
 
 from topstepx_backend.config.settings import TopstepConfig
 from topstepx_backend.core.event_bus import EventBus
 from topstepx_backend.networking.api_helpers import utc_now
+from topstepx_backend.utils.contract_validator import contract_validator
+
+if TYPE_CHECKING:
+    from topstepx_backend.services.contract_service import ContractService
 
 
 @dataclass
@@ -54,29 +58,16 @@ class MarketSubscriptionService:
     - Integration with PollingBarService
     - Validation of contract identifiers
     """
-    
-    # Contract validation patterns
-    # Full contractIds like "CON.F.US.EP.U25" are required by History API
-    # Symbols like "ES" are supported for backward compatibility
-    @staticmethod
-    def _is_valid_contract_format(contract_id: str) -> bool:
-        """Validate contract identifier format - accept both full contractIds and symbols."""
-        if not contract_id or not isinstance(contract_id, str):
-            return False
-        
-        # Full contractId format: CON.F.US.{SYMBOL}.{MONTH}{YEAR}
-        if contract_id.startswith("CON.F.US."):
-            return True
-            
-        # Legacy symbols: 2-6 character alphanumeric codes
-        if len(contract_id) >= 2 and len(contract_id) <= 6 and contract_id.isalnum():
-            return True
-            
-        return False
-    
-    def __init__(self, config: TopstepConfig, event_bus: EventBus):
+
+    def __init__(
+        self,
+        config: TopstepConfig,
+        event_bus: EventBus,
+        contract_service: Optional['ContractService'] = None,
+    ):
         self.config = config
         self.event_bus = event_bus
+        self.contract_service = contract_service
         self.logger = logging.getLogger(self.__class__.__name__)
         
         # State management
@@ -153,46 +144,62 @@ class MarketSubscriptionService:
             except Exception as e:
                 self.logger.error(f"Failed to save subscription state: {e}")
     
-    async def add_subscription(self, contract_id: str) -> Dict[str, Any]:
+    async def add_subscription(self, contract_identifier: str) -> Dict[str, Any]:
         """
         Add a contract subscription.
-        
+
+        Args:
+            contract_identifier: Contract ID or symbol to subscribe to
+
         Returns:
             Dict with success status and message
         """
-        # Validate contract format
-        if not self._is_valid_contract_format(contract_id):
+        validation = contract_validator.validate(contract_identifier)
+        if not validation.is_valid:
             self._stats["invalid_requests"] += 1
-            return {
-                "success": False,
-                "message": f"Invalid contract format: {contract_id}. Expected full contractId (CON.F.US.EP.U25) or symbol (ES)"
-            }
-        
+            return {"success": False, "message": validation.error_message or "Invalid contract identifier"}
+
+        contract_id = validation.normalized_id
+
+        if not contract_id:
+            if validation.requires_lookup and self.contract_service:
+                success, normalized_id, error = await contract_validator.normalize_identifier(
+                    contract_identifier, self.contract_service
+                )
+                if not success or not normalized_id:
+                    self._stats["invalid_requests"] += 1
+                    return {"success": False, "message": error or f"Failed to resolve symbol '{contract_identifier}'"}
+                contract_id = normalized_id
+            else:
+                self._stats["invalid_requests"] += 1
+                if validation.requires_lookup:
+                    message = f"Symbol '{contract_identifier}' requires lookup but no contract service available"
+                else:
+                    message = validation.error_message or f"Unable to normalize contract identifier '{contract_identifier}'"
+                return {"success": False, "message": message}
+
         async with self._state_lock:
             if contract_id in self._state.active_contracts:
-                return {
-                    "success": False,
-                    "message": f"Contract {contract_id} already subscribed"
-                }
-            
+                return {"success": False, "message": f"Contract {contract_id} already subscribed"}
+
             # Add subscription
             self._state.active_contracts.add(contract_id)
             self._state.last_updated = utc_now()
             self._state.update_count += 1
-            
+
             # Update stats
             self._stats["subscriptions_added"] += 1
             self._stats["last_operation"] = f"Added {contract_id}"
-        
+
         # Save state
         await self._save_state()
-        
+
         # Publish event
         await self.event_bus.publish(
             "system.market_subscription.added",
             {"contract_id": contract_id, "timestamp": utc_now()}
         )
-        
+
         self.logger.info(f"Added subscription for {contract_id}")
         return {
             "success": True,
@@ -270,13 +277,35 @@ class MarketSubscriptionService:
     async def validate_contracts(self, contracts: Set[str]) -> Dict[str, Any]:
         """
         Validate a set of contract identifiers.
-        
+
         Returns:
-            Dict with valid/invalid contracts
+            Dict with lists of valid and invalid contracts
         """
-        valid = [c for c in contracts if self._is_valid_contract_format(c)]
-        invalid = [c for c in contracts if not self._is_valid_contract_format(c)]
-        
+        from typing import List
+
+        valid: List[str] = []
+        invalid: List[str] = []
+
+        for identifier in contracts:
+            validation = contract_validator.validate(identifier)
+            if not validation.is_valid:
+                invalid.append(identifier)
+                continue
+
+            contract_id = validation.normalized_id
+
+            if not contract_id and validation.requires_lookup and self.contract_service:
+                success, normalized_id, _ = await contract_validator.normalize_identifier(
+                    identifier, self.contract_service
+                )
+                if success and normalized_id:
+                    contract_id = normalized_id
+
+            if contract_id:
+                valid.append(contract_id)
+            else:
+                invalid.append(identifier)
+
         return {
             "valid": valid,
             "invalid": invalid,


### PR DESCRIPTION
## Summary
- switch MarketSubscriptionService to contract_validator for contract ID handling
- normalize and lookup contract identifiers when adding subscriptions
- validate sets of contracts through contract_validator

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ae5c818a58833099e1d17636b5aec4