### PR TITLE
feat: add runtime strategy management

### DIFF
--- a/topstepx_backend/core/topics.py
+++ b/topstepx_backend/core/topics.py
@@ -96,3 +96,13 @@ def account_balance_update() -> str:
 def trade_update() -> str:
     """Topic for trade updates from SignalR"""
     return "trade.update"
+
+# Strategy management topics
+def strategy_add() -> str:
+    """Topic for runtime strategy addition"""
+    return "system.strategy.add"
+
+
+def strategy_remove() -> str:
+    """Topic for runtime strategy removal"""
+    return "system.strategy.remove"


### PR DESCRIPTION
## Summary
- add event-bus topics and StrategyRunner methods for adding and removing strategies at runtime
- allow StrategyRegistry to update or reload a single strategy config
- expose orchestrator helpers for hot-loading strategies via EventBus

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ae6504f5b0833099e0579f9124dd5b