### PR TITLE
docs: clarify project purpose

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,99 @@
 # CHILLLY
 
-This project contains backend services for managing market subscriptions and trading operations.
+CHILLLY is an event-driven trading backend for the TopstepX platform. It
+connects to TopstepX's APIs to collect market data, store it in SQLite, manage
+the order lifecycle, and execute user supplied strategies. An orchestrator
+bootstraps the system, wiring together loosely coupled services over a central
+event bus so that new components or strategies can be added with minimal
+friction.
 
-## Default Contract Subscriptions
+## Architecture Overview
+Independent services communicate exclusively via events:
 
-Operators can specify which contracts are subscribed to on startup by setting the `DEFAULT_CONTRACTS` environment variable or by providing it in an `.env` file. The value should be a comma-separated list of full contract identifiers. Example:
+- **EventBus** – topic-based routing layer with backpressure that decouples
+  producers and consumers.
+- **SystemClock** – deterministic clock publishing UTC-aligned minute boundaries
+  to drive bar creation.
+- **PollingBarService** – polls the TopstepX History API every 30 seconds,
+  emitting partial and finalized one-minute bars.
+- **TimeframeAggregator** – builds higher timeframes (5m–1d) from the one-minute
+  stream and can warm up from historical data.
+- **PersistenceService** – single-writer SQLite sink that records ticks and bars
+  by reacting to EventBus topics.
+- **SeriesCacheService** – keeps an in-memory sliding window of recent bars for
+  strategies or charting tools.
+- **HistoricalFetcher** – requests older bars on demand and feeds them back
+  through the EventBus.
+- **OrderService** – translates order requests to TopstepX REST calls,
+  correlates responses, and broadcasts status updates.
+- **MarketSubscriptionService** – tracks active contracts, persists the state,
+  and restores subscriptions on restart.
+- **Strategy framework** – registry and runner that load strategy classes which
+  subscribe to relevant topics and may publish order requests.
+
+### Program Flow
+1. The orchestrator loads configuration from environment variables,
+   authenticates with TopstepX, and starts the core services.
+2. Market data flows from `PollingBarService` into the `EventBus`; aggregators,
+   persistence, caches, and strategies consume the events.
+3. Strategies can submit orders by publishing to order topics. `OrderService`
+   sends the REST requests and publishes fills or rejections.
+4. On shutdown the orchestrator flushes outstanding tasks and persists
+   subscription state, allowing seamless restarts.
+
+## Repository Layout
+- `topstepx_backend/config` – configuration loading via environment variables and validation.
+- `topstepx_backend/auth` – authentication manager for TopstepX API with automatic token refresh.
+- `topstepx_backend/core` – event bus, system clock, and canonical topic helpers.
+- `topstepx_backend/data` – services for historical data retrieval, polling bar service, timeframe aggregation, and bar types.
+- `topstepx_backend/networking` – SignalR hub agents, API helpers, and rate limiter.
+- `topstepx_backend/services` – persistence, order management, contract discovery, series caching, and subscription management.
+- `topstepx_backend/strategy` – base strategy interfaces, runtime context, registry, examples, and runner.
+- `run_demo.py` – interactive demo for manual testing.
+- `tests` – pytest suite for core components.
+
+## Configuration
+Create an `.env` file or provide environment variables for authentication and runtime options:
 
 ```
+TOPSTEP_USERNAME=...
+TOPSTEP_API_KEY=...
+TOPSTEP_ACCOUNT_ID=...
+TOPSTEP_ACCOUNT_NAME=...
 DEFAULT_CONTRACTS=CON.F.US.EP.U25,CON.F.US.ENQ.U25
+DATABASE_PATH=data/topstepx.db
 ```
 
-When no prior subscription state exists, these contracts are loaded as the initial active subscriptions.
+`DEFAULT_CONTRACTS` defines initial market subscriptions when no saved state exists.
+
+## Running
+
+The orchestrator starts all services and strategy runner:
+
+```
+python -m topstepx_backend.orchestrator
+```
+
+For a lightweight demo that authenticates, subscribes to a contract, and optionally places a trade:
+
+```
+python run_demo.py
+```
+
+## Writing Strategies
+Strategies reside in `topstepx_backend/strategy`. To build your own algorithm:
+
+1. Subclass `BaseStrategy` and implement the `on_bar`/`on_tick` hooks of
+   interest.
+2. Register it with `register_strategy` so the orchestrator can discover it.
+3. The strategy receives events from the `EventBus` and can publish order
+   requests which the `OrderService` forwards to TopstepX.
+
+See `topstepx_backend/strategy/examples` for simple templates.
+
+## Testing
+Run the unit tests with pytest:
+
+```
+pytest
+```


### PR DESCRIPTION
## Summary
- expand README to explain how the event-driven trading backend works
- document program flow and steps for writing custom strategies

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ae675df9b0833089efe5995aab9d36