### PR TITLE
Add intraday strategy templates

### DIFF
--- a/strategies/__init__.py
+++ b/strategies/__init__.py
@@ -1,0 +1,17 @@
+"""User-contributed strategy plugins.
+
+This package collects standalone strategy implementations that can be
+discovered by the :class:`StrategyRegistry`. Each module defines a
+subclass of :class:`topstepx_backend.strategy.base.Strategy` and can be
+referenced in ``strategies.yaml`` using its module path.
+"""
+
+__all__ = [
+    "moving_average_crossover",
+    "bollinger_reversion",
+    "vwap_reversion",
+    "opening_range_breakout",
+    "macd_trend",
+    "rsi_reversal",
+]
+

--- a/strategies/bollinger_reversion.py
+++ b/strategies/bollinger_reversion.py
@@ -1,0 +1,108 @@
+"""Bollinger Band mean reversion strategy.
+
+The strategy buys when price closes below the lower band and sells when
+price closes above the upper band. Positions are exited when price returns
+to the moving average. Suitable for intraday mean reversion across futures
+markets.
+"""
+
+from dataclasses import dataclass
+from typing import Dict, Any, List, Optional
+
+from topstepx_backend.strategy.base import Strategy
+from topstepx_backend.strategy.context import StrategyContext
+from topstepx_backend.data.types import Bar
+
+
+@dataclass
+class BollingerState:
+    """Indicator and position state."""
+
+    prices: List[float]
+    sma: Optional[float] = None
+    std: Optional[float] = None
+
+
+class BollingerReversionStrategy(Strategy):
+    """Bollinger Band mean reversion strategy."""
+
+    def __init__(self, strategy_id: str, params: Dict[str, Any]):
+        super().__init__(strategy_id, params)
+
+        self.period = params.get("period", 20)
+        self.num_std = params.get("num_std", 2.0)
+        self.position_size = params.get("position_size", 1)
+
+        self.state = BollingerState(prices=[])
+        self.current_position = 0
+
+    def validate_params(self) -> bool:
+        if self.period < 2:
+            self.logger.error("period must be >= 2")
+            return False
+        if self.num_std <= 0:
+            self.logger.error("num_std must be > 0")
+            return False
+        if self.position_size <= 0:
+            self.logger.error("position_size must be > 0")
+            return False
+        return True
+
+    async def on_start(self, ctx: StrategyContext) -> None:
+        self.logger.info(
+            "Starting BollingerReversion strategy: period=%s num_std=%s size=%s",
+            self.period,
+            self.num_std,
+            self.position_size,
+        )
+        self.state = BollingerState(prices=[])
+        self.current_position = 0
+
+    async def on_bar(self, bar: Bar, ctx: StrategyContext) -> None:
+        self.state.prices.append(bar.close)
+        if len(self.state.prices) > self.period + 5:
+            self.state.prices = self.state.prices[-(self.period + 5) :]
+
+        if len(self.state.prices) >= self.period:
+            window = self.state.prices[-self.period :]
+            sma = sum(window) / self.period
+            variance = sum((p - sma) ** 2 for p in window) / self.period
+            std = variance ** 0.5
+            self.state.sma = sma
+            self.state.std = std
+        else:
+            return
+
+        upper = self.state.sma + self.num_std * self.state.std
+        lower = self.state.sma - self.num_std * self.state.std
+
+        if self.current_position == 0:
+            if bar.close < lower:
+                if await ctx.buy_market(self.position_size, "bb_long"):
+                    self.current_position = self.position_size
+            elif bar.close > upper:
+                if await ctx.sell_market(self.position_size, "bb_short"):
+                    self.current_position = -self.position_size
+        elif self.current_position > 0 and bar.close >= self.state.sma:
+            await ctx.sell_market(self.current_position, "bb_exit")
+            self.current_position = 0
+        elif self.current_position < 0 and bar.close <= self.state.sma:
+            await ctx.buy_market(abs(self.current_position), "bb_exit")
+            self.current_position = 0
+
+        self.logger.debug(
+            "close=%s sma=%s std=%s upper=%s lower=%s position=%s",
+            bar.close,
+            self.state.sma,
+            self.state.std,
+            upper,
+            lower,
+            self.current_position,
+        )
+
+    async def on_stop(self, ctx: StrategyContext) -> None:
+        if self.current_position > 0:
+            await ctx.sell_market(self.current_position, "strategy_stop")
+        elif self.current_position < 0:
+            await ctx.buy_market(abs(self.current_position), "strategy_stop")
+

--- a/strategies/macd_trend.py
+++ b/strategies/macd_trend.py
@@ -1,0 +1,135 @@
+"""MACD trend-following strategy.
+
+Uses the Moving Average Convergence Divergence indicator. A long position
+is taken when the MACD line crosses above the signal line and a short
+position on the opposite cross.
+"""
+
+from dataclasses import dataclass
+from typing import Dict, Any, Optional
+
+from topstepx_backend.strategy.base import Strategy
+from topstepx_backend.strategy.context import StrategyContext
+from topstepx_backend.data.types import Bar
+
+
+@dataclass
+class MACDState:
+    """State for MACD calculations."""
+
+    fast_ema: Optional[float] = None
+    slow_ema: Optional[float] = None
+    macd: Optional[float] = None
+    signal: Optional[float] = None
+
+
+class MACDTrendStrategy(Strategy):
+    """MACD trend-following strategy."""
+
+    def __init__(self, strategy_id: str, params: Dict[str, Any]):
+        super().__init__(strategy_id, params)
+
+        self.fast_period = params.get("fast_period", 12)
+        self.slow_period = params.get("slow_period", 26)
+        self.signal_period = params.get("signal_period", 9)
+        self.position_size = params.get("position_size", 1)
+
+        self.fast_mult = 2 / (self.fast_period + 1)
+        self.slow_mult = 2 / (self.slow_period + 1)
+        self.signal_mult = 2 / (self.signal_period + 1)
+
+        self.state = MACDState()
+        self.current_position = 0
+        self.last_signal: Optional[str] = None
+
+    def validate_params(self) -> bool:
+        if self.fast_period <= 0 or self.slow_period <= 0 or self.signal_period <= 0:
+            self.logger.error("periods must be positive")
+            return False
+        if self.fast_period >= self.slow_period:
+            self.logger.error("fast_period must be < slow_period")
+            return False
+        if self.position_size <= 0:
+            self.logger.error("position_size must be > 0")
+            return False
+        return True
+
+    async def on_start(self, ctx: StrategyContext) -> None:
+        self.logger.info(
+            "Starting MACDTrend strategy: fast=%s slow=%s signal=%s size=%s",
+            self.fast_period,
+            self.slow_period,
+            self.signal_period,
+            self.position_size,
+        )
+        self.state = MACDState()
+        self.current_position = 0
+        self.last_signal = None
+
+    async def on_bar(self, bar: Bar, ctx: StrategyContext) -> None:
+        price = bar.close
+        if self.state.fast_ema is None:
+            self.state.fast_ema = price
+            self.state.slow_ema = price
+            return
+
+        self.state.fast_ema = (
+            price * self.fast_mult + self.state.fast_ema * (1 - self.fast_mult)
+        )
+        self.state.slow_ema = (
+            price * self.slow_mult + self.state.slow_ema * (1 - self.slow_mult)
+        )
+        self.state.macd = self.state.fast_ema - self.state.slow_ema
+
+        if self.state.signal is None:
+            self.state.signal = self.state.macd
+            return
+
+        self.state.signal = (
+            self.state.macd * self.signal_mult
+            + self.state.signal * (1 - self.signal_mult)
+        )
+
+        signal: Optional[str] = None
+        if self.state.macd > self.state.signal:
+            signal = "buy"
+        elif self.state.macd < self.state.signal:
+            signal = "sell"
+
+        if signal and signal != self.last_signal:
+            if signal == "buy":
+                await self._go_long(ctx)
+            else:
+                await self._go_short(ctx)
+            self.last_signal = signal
+
+        self.logger.debug(
+            "close=%s macd=%s signal=%s position=%s",
+            price,
+            self.state.macd,
+            self.state.signal,
+            self.current_position,
+        )
+
+    async def on_stop(self, ctx: StrategyContext) -> None:
+        if self.current_position > 0:
+            await ctx.sell_market(self.current_position, "strategy_stop")
+        elif self.current_position < 0:
+            await ctx.buy_market(abs(self.current_position), "strategy_stop")
+
+    async def _go_long(self, ctx: StrategyContext) -> None:
+        if self.current_position < 0:
+            await ctx.buy_market(abs(self.current_position), "reverse")
+            self.current_position = 0
+        if self.current_position == 0:
+            if await ctx.buy_market(self.position_size, "long"):
+                self.current_position = self.position_size
+
+    async def _go_short(self, ctx: StrategyContext) -> None:
+        if self.current_position > 0:
+            await ctx.sell_market(self.current_position, "reverse")
+            self.current_position = 0
+        if self.current_position == 0:
+            if await ctx.sell_market(self.position_size, "short"):
+                self.current_position = -self.position_size
+

--- a/strategies/moving_average_crossover.py
+++ b/strategies/moving_average_crossover.py
@@ -1,0 +1,118 @@
+"""Moving Average Crossover strategy for intraday trading.
+
+This strategy goes long when a fast moving average crosses above a slow
+moving average and goes short on the opposite cross. It can be applied to
+any futures market by configuring the contract and timeframe in the
+strategy configuration.
+"""
+
+from dataclasses import dataclass
+from typing import Dict, Any, List, Optional
+
+from topstepx_backend.strategy.base import Strategy
+from topstepx_backend.strategy.context import StrategyContext
+from topstepx_backend.data.types import Bar
+
+
+@dataclass
+class MACState:
+    """Indicator and position state for the strategy."""
+
+    prices: List[float]
+    fast_ma: Optional[float] = None
+    slow_ma: Optional[float] = None
+
+
+class MovingAverageCrossoverStrategy(Strategy):
+    """Dual moving average crossover strategy."""
+
+    def __init__(self, strategy_id: str, params: Dict[str, Any]):
+        super().__init__(strategy_id, params)
+
+        self.fast_period = params.get("fast_period", 10)
+        self.slow_period = params.get("slow_period", 30)
+        self.position_size = params.get("position_size", 1)
+
+        self.state = MACState(prices=[])
+        self.current_position = 0
+        self.last_signal: Optional[str] = None  # 'buy' or 'sell'
+
+    def validate_params(self) -> bool:
+        if self.fast_period < 1 or self.slow_period < 2:
+            self.logger.error("Periods must be positive")
+            return False
+        if self.fast_period >= self.slow_period:
+            self.logger.error("fast_period must be < slow_period")
+            return False
+        if self.position_size <= 0:
+            self.logger.error("position_size must be > 0")
+            return False
+        return True
+
+    async def on_start(self, ctx: StrategyContext) -> None:
+        self.logger.info(
+            "Starting MovingAverageCrossover strategy: fast=%s slow=%s size=%s",
+            self.fast_period,
+            self.slow_period,
+            self.position_size,
+        )
+        self.state = MACState(prices=[])
+        self.current_position = 0
+        self.last_signal = None
+
+    async def on_bar(self, bar: Bar, ctx: StrategyContext) -> None:
+        self.state.prices.append(bar.close)
+        max_len = self.slow_period + 5
+        if len(self.state.prices) > max_len:
+            self.state.prices = self.state.prices[-max_len:]
+
+        if len(self.state.prices) >= self.fast_period:
+            self.state.fast_ma = sum(self.state.prices[-self.fast_period:]) / self.fast_period
+        if len(self.state.prices) >= self.slow_period:
+            self.state.slow_ma = sum(self.state.prices[-self.slow_period:]) / self.slow_period
+
+        if self.state.fast_ma is None or self.state.slow_ma is None:
+            return
+
+        signal: Optional[str] = None
+        if self.state.fast_ma > self.state.slow_ma:
+            signal = "buy"
+        elif self.state.fast_ma < self.state.slow_ma:
+            signal = "sell"
+
+        if signal and signal != self.last_signal:
+            if signal == "buy":
+                await self._go_long(ctx)
+            elif signal == "sell":
+                await self._go_short(ctx)
+            self.last_signal = signal
+
+        self.logger.debug(
+            "close=%s fast_ma=%s slow_ma=%s position=%s",
+            bar.close,
+            self.state.fast_ma,
+            self.state.slow_ma,
+            self.current_position,
+        )
+
+    async def on_stop(self, ctx: StrategyContext) -> None:
+        if self.current_position > 0:
+            await ctx.sell_market(self.current_position, "strategy_stop")
+        elif self.current_position < 0:
+            await ctx.buy_market(abs(self.current_position), "strategy_stop")
+
+    async def _go_long(self, ctx: StrategyContext) -> None:
+        if self.current_position < 0:
+            await ctx.buy_market(abs(self.current_position), "reverse")
+            self.current_position = 0
+        if self.current_position == 0:
+            if await ctx.buy_market(self.position_size, "long"):
+                self.current_position = self.position_size
+
+    async def _go_short(self, ctx: StrategyContext) -> None:
+        if self.current_position > 0:
+            await ctx.sell_market(self.current_position, "reverse")
+            self.current_position = 0
+        if self.current_position == 0:
+            if await ctx.sell_market(self.position_size, "short"):
+                self.current_position = -self.position_size

--- a/strategies/opening_range_breakout.py
+++ b/strategies/opening_range_breakout.py
@@ -1,0 +1,120 @@
+"""Opening Range Breakout strategy.
+
+Defines an opening range from the first N minutes of trading and takes a
+position when price breaks out of that range. Works on any intraday
+timeframe where bars are timestamped in UTC.
+"""
+
+from dataclasses import dataclass
+from datetime import timedelta
+from typing import Dict, Any, Optional
+
+from topstepx_backend.strategy.base import Strategy
+from topstepx_backend.strategy.context import StrategyContext
+from topstepx_backend.data.types import Bar
+
+
+@dataclass
+class RangeState:
+    """State for opening range tracking."""
+
+    range_high: Optional[float] = None
+    range_low: Optional[float] = None
+    range_end: Optional[str] = None
+    range_complete: bool = False
+
+
+class OpeningRangeBreakoutStrategy(Strategy):
+    """Opening range breakout strategy."""
+
+    def __init__(self, strategy_id: str, params: Dict[str, Any]):
+        super().__init__(strategy_id, params)
+
+        self.range_minutes = params.get("range_minutes", 30)
+        self.position_size = params.get("position_size", 1)
+
+        self.state = RangeState()
+        self.current_position = 0
+
+    def validate_params(self) -> bool:
+        if self.range_minutes <= 0:
+            self.logger.error("range_minutes must be > 0")
+            return False
+        if self.position_size <= 0:
+            self.logger.error("position_size must be > 0")
+            return False
+        return True
+
+    async def on_start(self, ctx: StrategyContext) -> None:
+        self.logger.info(
+            "Starting OpeningRangeBreakout strategy: range_minutes=%s size=%s",
+            self.range_minutes,
+            self.position_size,
+        )
+        self.state = RangeState()
+        self.current_position = 0
+
+    async def on_bar(self, bar: Bar, ctx: StrategyContext) -> None:
+        if not self.state.range_complete:
+            await self._update_range(bar)
+            return
+
+        if self.current_position == 0:
+            if bar.high > self.state.range_high:
+                if await ctx.buy_market(self.position_size, "or_long"):
+                    self.current_position = self.position_size
+            elif bar.low < self.state.range_low:
+                if await ctx.sell_market(self.position_size, "or_short"):
+                    self.current_position = -self.position_size
+        else:
+            if (
+                self.current_position > 0 and bar.low <= self.state.range_low
+            ) or (
+                self.current_position < 0 and bar.high >= self.state.range_high
+            ):
+                if self.current_position > 0:
+                    await ctx.sell_market(self.current_position, "or_exit")
+                else:
+                    await ctx.buy_market(abs(self.current_position), "or_exit")
+                self.current_position = 0
+
+        self.logger.debug(
+            "close=%s range_high=%s range_low=%s position=%s",
+            bar.close,
+            self.state.range_high,
+            self.state.range_low,
+            self.current_position,
+        )
+
+    async def _update_range(self, bar: Bar) -> None:
+        if self.state.range_high is None:
+            self.state.range_high = bar.high
+            self.state.range_low = bar.low
+            self.state.range_end = (
+                bar.timestamp + timedelta(minutes=self.range_minutes)
+            ).isoformat()
+        else:
+            self.state.range_high = max(self.state.range_high, bar.high)
+            self.state.range_low = min(self.state.range_low, bar.low)
+
+        if bar.timestamp >= self._range_end_dt():
+            self.state.range_complete = True
+            self.logger.info(
+                "Opening range complete: high=%s low=%s",
+                self.state.range_high,
+                self.state.range_low,
+            )
+
+    def _range_end_dt(self):
+        if not self.state.range_end:
+            return None
+        from datetime import datetime
+
+        return datetime.fromisoformat(self.state.range_end)
+
+    async def on_stop(self, ctx: StrategyContext) -> None:
+        if self.current_position > 0:
+            await ctx.sell_market(self.current_position, "strategy_stop")
+        elif self.current_position < 0:
+            await ctx.buy_market(abs(self.current_position), "strategy_stop")
+

--- a/strategies/rsi_reversal.py
+++ b/strategies/rsi_reversal.py
@@ -1,0 +1,110 @@
+"""RSI reversal strategy.
+
+Enters long when RSI drops below an oversold threshold and short when RSI
+exceeds an overbought threshold. Positions are exited when RSI returns to
+the neutral zone.
+"""
+
+from dataclasses import dataclass
+from typing import Dict, Any, List, Optional
+
+from topstepx_backend.strategy.base import Strategy
+from topstepx_backend.strategy.context import StrategyContext
+from topstepx_backend.data.types import Bar
+
+
+@dataclass
+class RSIState:
+    """State for RSI calculation."""
+
+    prices: List[float]
+    gains: List[float]
+    losses: List[float]
+    rsi: Optional[float] = None
+
+
+class RSIReversalStrategy(Strategy):
+    """RSI reversal strategy."""
+
+    def __init__(self, strategy_id: str, params: Dict[str, Any]):
+        super().__init__(strategy_id, params)
+
+        self.period = params.get("period", 14)
+        self.overbought = params.get("overbought", 70)
+        self.oversold = params.get("oversold", 30)
+        self.position_size = params.get("position_size", 1)
+
+        self.state = RSIState(prices=[], gains=[], losses=[])
+        self.current_position = 0
+
+    def validate_params(self) -> bool:
+        if self.period < 2:
+            self.logger.error("period must be >= 2")
+            return False
+        if self.overbought <= self.oversold:
+            self.logger.error("overbought must be > oversold")
+            return False
+        if self.position_size <= 0:
+            self.logger.error("position_size must be > 0")
+            return False
+        return True
+
+    async def on_start(self, ctx: StrategyContext) -> None:
+        self.logger.info(
+            "Starting RSIReversal strategy: period=%s size=%s",
+            self.period,
+            self.position_size,
+        )
+        self.state = RSIState(prices=[], gains=[], losses=[])
+        self.current_position = 0
+
+    async def on_bar(self, bar: Bar, ctx: StrategyContext) -> None:
+        price = bar.close
+        self.state.prices.append(price)
+        if len(self.state.prices) >= 2:
+            change = price - self.state.prices[-2]
+            self.state.gains.append(max(change, 0))
+            self.state.losses.append(abs(min(change, 0)))
+        if len(self.state.gains) > self.period:
+            self.state.gains = self.state.gains[-self.period :]
+            self.state.losses = self.state.losses[-self.period :]
+
+        if len(self.state.gains) < self.period:
+            return
+
+        avg_gain = sum(self.state.gains) / self.period
+        avg_loss = sum(self.state.losses) / self.period
+        if avg_loss == 0:
+            rsi = 100.0
+        else:
+            rs = avg_gain / avg_loss
+            rsi = 100 - (100 / (1 + rs))
+        self.state.rsi = rsi
+
+        if self.current_position == 0:
+            if rsi < self.oversold:
+                if await ctx.buy_market(self.position_size, "rsi_long"):
+                    self.current_position = self.position_size
+            elif rsi > self.overbought:
+                if await ctx.sell_market(self.position_size, "rsi_short"):
+                    self.current_position = -self.position_size
+        elif self.current_position > 0 and rsi >= self.oversold:
+            await ctx.sell_market(self.current_position, "rsi_exit")
+            self.current_position = 0
+        elif self.current_position < 0 and rsi <= self.overbought:
+            await ctx.buy_market(abs(self.current_position), "rsi_exit")
+            self.current_position = 0
+
+        self.logger.debug(
+            "close=%s rsi=%s position=%s",
+            price,
+            self.state.rsi,
+            self.current_position,
+        )
+
+    async def on_stop(self, ctx: StrategyContext) -> None:
+        if self.current_position > 0:
+            await ctx.sell_market(self.current_position, "strategy_stop")
+        elif self.current_position < 0:
+            await ctx.buy_market(abs(self.current_position), "strategy_stop")
+

--- a/strategies/vwap_reversion.py
+++ b/strategies/vwap_reversion.py
@@ -1,0 +1,99 @@
+"""VWAP mean reversion strategy.
+
+Trades when price deviates from the Volume Weighted Average Price (VWAP)
+by a configurable number of ticks and exits when price reverts back to
+the VWAP. Works on any futures market that provides volume data.
+"""
+
+from dataclasses import dataclass
+from typing import Dict, Any, Optional
+
+from topstepx_backend.strategy.base import Strategy
+from topstepx_backend.strategy.context import StrategyContext
+from topstepx_backend.data.types import Bar
+
+
+@dataclass
+class VWAPState:
+    """Accumulated VWAP state."""
+
+    total_volume: float = 0.0
+    total_vp: float = 0.0  # volume * price
+    vwap: Optional[float] = None
+
+
+class VWAPReversionStrategy(Strategy):
+    """VWAP mean reversion strategy."""
+
+    def __init__(self, strategy_id: str, params: Dict[str, Any]):
+        super().__init__(strategy_id, params)
+
+        self.deviation_ticks = params.get("deviation_ticks", 4)
+        self.tick_size = params.get("tick_size", 0.25)
+        self.position_size = params.get("position_size", 1)
+
+        self.state = VWAPState()
+        self.current_position = 0
+
+    def validate_params(self) -> bool:
+        if self.deviation_ticks <= 0:
+            self.logger.error("deviation_ticks must be > 0")
+            return False
+        if self.tick_size <= 0:
+            self.logger.error("tick_size must be > 0")
+            return False
+        if self.position_size <= 0:
+            self.logger.error("position_size must be > 0")
+            return False
+        return True
+
+    async def on_start(self, ctx: StrategyContext) -> None:
+        self.logger.info(
+            "Starting VWAPReversion strategy: dev_ticks=%s size=%s",
+            self.deviation_ticks,
+            self.position_size,
+        )
+        self.state = VWAPState()
+        self.current_position = 0
+
+    async def on_bar(self, bar: Bar, ctx: StrategyContext) -> None:
+        self.state.total_volume += bar.volume
+        self.state.total_vp += bar.close * bar.volume
+        if self.state.total_volume > 0:
+            self.state.vwap = self.state.total_vp / self.state.total_volume
+        else:
+            return
+
+        deviation = self.deviation_ticks * self.tick_size
+        upper = self.state.vwap + deviation
+        lower = self.state.vwap - deviation
+
+        if self.current_position == 0:
+            if bar.close < lower:
+                if await ctx.buy_market(self.position_size, "vwap_long"):
+                    self.current_position = self.position_size
+            elif bar.close > upper:
+                if await ctx.sell_market(self.position_size, "vwap_short"):
+                    self.current_position = -self.position_size
+        elif self.current_position > 0 and bar.close >= self.state.vwap:
+            await ctx.sell_market(self.current_position, "vwap_exit")
+            self.current_position = 0
+        elif self.current_position < 0 and bar.close <= self.state.vwap:
+            await ctx.buy_market(abs(self.current_position), "vwap_exit")
+            self.current_position = 0
+
+        self.logger.debug(
+            "close=%s vwap=%s upper=%s lower=%s position=%s",
+            bar.close,
+            self.state.vwap,
+            upper,
+            lower,
+            self.current_position,
+        )
+
+    async def on_stop(self, ctx: StrategyContext) -> None:
+        if self.current_position > 0:
+            await ctx.sell_market(self.current_position, "strategy_stop")
+        elif self.current_position < 0:
+            await ctx.buy_market(abs(self.current_position), "strategy_stop")
+

--- a/topstepx_backend/strategy/configs/strategies.yaml
+++ b/topstepx_backend/strategy/configs/strategies.yaml
@@ -37,3 +37,101 @@ strategies:
       max_daily_loss: 750.0
       max_order_size: 1
       max_orders_per_minute: 3
+
+  # Moving Average Crossover Strategy
+  - strategy_id: "ma_crossover_generic"
+    class: "strategies.moving_average_crossover.MovingAverageCrossoverStrategy"
+    account_id: 123456
+    contract_id: "ESU5"
+    timeframe: "5m"
+    params:
+      fast_period: 10
+      slow_period: 30
+      position_size: 1
+    risk:
+      max_position_size: 2
+      max_daily_loss: 500.0
+      max_order_size: 1
+      max_orders_per_minute: 5
+
+
+  # Bollinger Band Mean Reversion
+  - strategy_id: "bollinger_reversion_generic"
+    class: "strategies.bollinger_reversion.BollingerReversionStrategy"
+    account_id: 123456
+    contract_id: "NQU5"
+    timeframe: "1m"
+    params:
+      period: 20
+      num_std: 2
+      position_size: 1
+    risk:
+      max_position_size: 2
+      max_daily_loss: 500.0
+      max_order_size: 1
+      max_orders_per_minute: 5
+
+  # VWAP Mean Reversion
+  - strategy_id: "vwap_reversion_generic"
+    class: "strategies.vwap_reversion.VWAPReversionStrategy"
+    account_id: 123456
+    contract_id: "CLV5"
+    timeframe: "1m"
+    params:
+      deviation_ticks: 4
+      tick_size: 0.01
+      position_size: 1
+    risk:
+      max_position_size: 2
+      max_daily_loss: 500.0
+      max_order_size: 1
+      max_orders_per_minute: 5
+
+  # Opening Range Breakout
+  - strategy_id: "opening_range_generic"
+    class: "strategies.opening_range_breakout.OpeningRangeBreakoutStrategy"
+    account_id: 123456
+    contract_id: "GCZ5"
+    timeframe: "1m"
+    params:
+      range_minutes: 30
+      position_size: 1
+    risk:
+      max_position_size: 2
+      max_daily_loss: 500.0
+      max_order_size: 1
+      max_orders_per_minute: 5
+
+  # MACD Trend Strategy
+  - strategy_id: "macd_trend_generic"
+    class: "strategies.macd_trend.MACDTrendStrategy"
+    account_id: 123456
+    contract_id: "YMZ5"
+    timeframe: "5m"
+    params:
+      fast_period: 12
+      slow_period: 26
+      signal_period: 9
+      position_size: 1
+    risk:
+      max_position_size: 2
+      max_daily_loss: 500.0
+      max_order_size: 1
+      max_orders_per_minute: 5
+
+  # RSI Reversal Strategy
+  - strategy_id: "rsi_reversal_generic"
+    class: "strategies.rsi_reversal.RSIReversalStrategy"
+    account_id: 123456
+    contract_id: "6EU5"
+    timeframe: "1m"
+    params:
+      period: 14
+      overbought: 70
+      oversold: 30
+      position_size: 1
+    risk:
+      max_position_size: 2
+      max_daily_loss: 500.0
+      max_order_size: 1
+      max_orders_per_minute: 5


### PR DESCRIPTION
## Summary
- add moving average crossover, Bollinger reversion, VWAP reversion, opening range breakout, MACD trend, and RSI reversal strategy modules
- update strategies.yaml with configuration templates for these intraday strategies

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ae75326d5c83309ce6afc48a0c8fa6