### PR TITLE
Add base Service abstraction and streamline orchestrator startup

### DIFF
--- a/topstepx_backend/core/service.py
+++ b/topstepx_backend/core/service.py
@@ -1,0 +1,30 @@
+import asyncio
+import logging
+from abc import ABC, abstractmethod
+from typing import Any, Dict
+
+
+class Service(ABC):
+    """Base class for asynchronous services with metrics support."""
+
+    def __init__(self) -> None:
+        self.logger = logging.getLogger(self.__class__.__name__)
+        self._running = False
+        self._metrics: Dict[str, Any] = {}
+        self._metrics_lock = asyncio.Lock()
+
+    @abstractmethod
+    async def start(self) -> None:
+        """Start the service."""
+        ...
+
+    @abstractmethod
+    async def stop(self) -> None:
+        """Stop the service."""
+        ...
+
+    def get_metrics(self) -> Dict[str, Any]:
+        """Return service metrics including running state."""
+        base = {"running": self._running}
+        base.update(self._metrics)
+        return base

--- a/topstepx_backend/services/risk_manager.py
+++ b/topstepx_backend/services/risk_manager.py
@@ -3,9 +3,10 @@ import logging
 from dataclasses import dataclass
 from typing import Dict, Tuple, Any
 
-from topstepx_backend.core.event_bus import EventBus, Subscription
-from topstepx_backend.core.topics import order_fill_update, account_position_update
 from topstepx_backend.config.settings import TopstepConfig
+from topstepx_backend.core.event_bus import EventBus, Subscription
+from topstepx_backend.core.service import Service
+from topstepx_backend.core.topics import order_fill_update, account_position_update
 from topstepx_backend.data.types import OrderIntent, OrderSide
 
 
@@ -17,10 +18,11 @@ class PositionState:
     pnl: float = 0.0
 
 
-class RiskManager:
+class RiskManager(Service):
     """Manages trading risk limits and account state."""
 
     def __init__(self, event_bus: EventBus, config: TopstepConfig):
+        super().__init__()
         self.event_bus = event_bus
         self.config = config
         self.logger = logging.getLogger(__name__)
@@ -28,7 +30,6 @@ class RiskManager:
         self.account_pnl: Dict[int, float] = {}
         self._subscriptions: list[Subscription] = []
         self._tasks: list[asyncio.Task] = []
-        self._running = False
 
     async def start(self) -> None:
         """Subscribe to necessary topics."""


### PR DESCRIPTION
## Summary
- introduce core `Service` base class with async start/stop and metrics
- refactor `PollingBarService` and `RiskManager` to inherit from `Service`
- simplify orchestrator by iterating through a list of services for start/stop

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ae77998f748330aec39beb51f818be