### PR TITLE
feat(api): add response models

### DIFF
--- a/tests/test_api_server.py
+++ b/tests/test_api_server.py
@@ -2,7 +2,7 @@ import asyncio
 
 from fastapi.testclient import TestClient
 
-from topstepx_backend.api.server import APIServer
+from topstepx_backend.api.server import APIServer, StatusResponse, StrategyResponse
 from topstepx_backend.core.event_bus import EventBus
 
 
@@ -42,7 +42,8 @@ def test_rest_endpoints():
     # system status
     resp = client.get("/status")
     assert resp.status_code == 200
-    assert resp.json()["status"] == "ok"
+    data = StatusResponse(**resp.json())
+    assert data.status == "ok"
     assert orch.status_called
 
     # order submission
@@ -56,15 +57,21 @@ def test_rest_endpoints():
     }
     resp = client.post("/orders", json=order)
     assert resp.status_code == 200
+    data = StatusResponse(**resp.json())
+    assert data.status == "submitted"
     assert orch.submit_payload == order
 
     # strategy add/remove
     resp = client.post("/strategies", json={"name": "test"})
     assert resp.status_code == 200
+    data = StrategyResponse(**resp.json())
+    assert data.status == "added"
     assert orch.add_payload == {"name": "test"}
 
     resp = client.delete("/strategies/abc")
     assert resp.status_code == 200
+    data = StrategyResponse(**resp.json())
+    assert data.status == "removed"
     assert orch.remove_id == "abc"
 
 

--- a/topstepx_backend/api/server.py
+++ b/topstepx_backend/api/server.py
@@ -30,6 +30,21 @@ class OrderRequest(BaseModel):
     custom_tag: Optional[str] = None
 
 
+class StatusResponse(BaseModel):
+    """Standard response schema with a status message."""
+
+    status: str
+
+    class Config:
+        extra = "allow"
+
+
+class StrategyResponse(BaseModel):
+    """Response schema for strategy operations."""
+
+    status: str
+
+
 class APIServer(Service):
     """FastAPI based HTTP server exposing orchestrator operations."""
 
@@ -56,24 +71,24 @@ class APIServer(Service):
     def _setup_routes(self) -> None:
         """Configure REST and WebSocket endpoints."""
 
-        @self.app.get("/status")
-        async def status() -> Dict[str, Any]:
-            return self.orchestrator.get_system_status()
+        @self.app.get("/status", response_model=StatusResponse)
+        async def status() -> StatusResponse:
+            return StatusResponse(**self.orchestrator.get_system_status())
 
-        @self.app.post("/orders")
-        async def submit_order(order: OrderRequest) -> Dict[str, str]:
+        @self.app.post("/orders", response_model=StatusResponse)
+        async def submit_order(order: OrderRequest) -> StatusResponse:
             await self.orchestrator.submit_order(order.dict())
-            return {"status": "submitted"}
+            return StatusResponse(status="submitted")
 
-        @self.app.post("/strategies")
-        async def add_strategy(config: Dict[str, Any]) -> Dict[str, str]:
+        @self.app.post("/strategies", response_model=StrategyResponse)
+        async def add_strategy(config: Dict[str, Any]) -> StrategyResponse:
             await self.orchestrator.add_strategy(config)
-            return {"status": "added"}
+            return StrategyResponse(status="added")
 
-        @self.app.delete("/strategies/{strategy_id}")
-        async def remove_strategy(strategy_id: str) -> Dict[str, str]:
+        @self.app.delete("/strategies/{strategy_id}", response_model=StrategyResponse)
+        async def remove_strategy(strategy_id: str) -> StrategyResponse:
             await self.orchestrator.remove_strategy(strategy_id)
-            return {"status": "removed"}
+            return StrategyResponse(status="removed")
 
         @self.app.websocket("/ws/{token}")
         async def websocket_endpoint(websocket: WebSocket, token: str) -> None:


### PR DESCRIPTION
## Summary
- add StatusResponse and StrategyResponse Pydantic models for consistent API responses
- return these models from status, order, and strategy routes
- test API server responses using new schemas

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*


------
https://chatgpt.com/codex/tasks/task_e_68ae7f6719a88330b952158c58807a7d