### PR TITLE
refactor: move order and strategy routes to routers

### DIFF
--- a/topstepx_backend/api/routes/orders.py
+++ b/topstepx_backend/api/routes/orders.py
@@ -1,0 +1,11 @@
+from fastapi import APIRouter, Request
+
+from topstepx_backend.api.server import OrderRequest, StatusResponse
+
+router = APIRouter()
+
+@router.post("/orders", response_model=StatusResponse)
+async def submit_order(order: OrderRequest, request: Request) -> StatusResponse:
+    orchestrator = request.app.state.orchestrator
+    await orchestrator.submit_order(order.dict())
+    return StatusResponse(status="submitted")

--- a/topstepx_backend/api/routes/strategies.py
+++ b/topstepx_backend/api/routes/strategies.py
@@ -1,0 +1,19 @@
+from typing import Any, Dict
+
+from fastapi import APIRouter, Request
+
+from topstepx_backend.api.server import StrategyResponse
+
+router = APIRouter()
+
+@router.post("/strategies", response_model=StrategyResponse)
+async def add_strategy(config: Dict[str, Any], request: Request) -> StrategyResponse:
+    orchestrator = request.app.state.orchestrator
+    await orchestrator.add_strategy(config)
+    return StrategyResponse(status="added")
+
+@router.delete("/strategies/{strategy_id}", response_model=StrategyResponse)
+async def remove_strategy(strategy_id: str, request: Request) -> StrategyResponse:
+    orchestrator = request.app.state.orchestrator
+    await orchestrator.remove_strategy(strategy_id)
+    return StrategyResponse(status="removed")


### PR DESCRIPTION
## Summary
- refactor API server to mount dedicated order and strategy routers
- split order and strategy endpoints into standalone modules

## Testing
- `pytest -q` *(fails: No module named 'fastapi')*


------
https://chatgpt.com/codex/tasks/task_e_68ae843853b883309dd7b4dd7621992f