### PR TITLE
Add strategy analytics service

### DIFF
--- a/tests/services/test_strategy_analytics.py
+++ b/tests/services/test_strategy_analytics.py
@@ -1,0 +1,28 @@
+import asyncio
+
+from topstepx_backend.core.event_bus import EventBus
+from topstepx_backend.analytics.strategy_analytics import StrategyAnalytics
+from topstepx_backend.core.topics import order_fill_update, account_position_update
+
+
+def test_strategy_analytics_metrics():
+    async def scenario():
+        bus = EventBus()
+        await bus.start()
+        sa = StrategyAnalytics(bus)
+        await sa.start()
+
+        # simulate events
+        await bus.publish(order_fill_update(), {"custom_tag": "s1_0_123", "pnl": 5})
+        await bus.publish(account_position_update(), {"strategy_id": "s1", "position": 2})
+        await asyncio.sleep(0.1)
+
+        metrics = sa.get_metrics()
+        assert metrics["s1"]["trades_executed"] == 1
+        assert metrics["s1"]["realized_pnl"] == 5
+        assert metrics["s1"]["position"] == 2
+
+        await sa.stop()
+        await bus.stop()
+
+    asyncio.run(scenario())

--- a/topstepx_backend/analytics/__init__.py
+++ b/topstepx_backend/analytics/__init__.py
@@ -1,0 +1,1 @@
+"""Analytics services for TopstepX backend."""

--- a/topstepx_backend/analytics/strategy_analytics.py
+++ b/topstepx_backend/analytics/strategy_analytics.py
@@ -1,0 +1,105 @@
+import asyncio
+import logging
+from typing import Any, Dict, List
+
+from topstepx_backend.core.event_bus import EventBus, Subscription
+from topstepx_backend.core.service import Service
+from topstepx_backend.core.topics import order_fill_update, account_position_update
+
+
+class StrategyAnalytics(Service):
+    """Aggregates per-strategy trading metrics."""
+
+    def __init__(self, event_bus: EventBus):
+        super().__init__()
+        self.event_bus = event_bus
+        self.logger = logging.getLogger(__name__)
+        self._subscriptions: List[Subscription] = []
+        self._tasks: List[asyncio.Task] = []
+        # strategy_id -> metrics
+        self._metrics: Dict[str, Dict[str, Any]] = {}
+
+    async def start(self) -> None:
+        """Start analytics consumers."""
+        fill_sub = await self.event_bus.subscribe(
+            order_fill_update(), critical=False, maxsize=2000
+        )
+        pos_sub = await self.event_bus.subscribe(
+            account_position_update(), critical=False, maxsize=2000
+        )
+        self._subscriptions.extend([fill_sub, pos_sub])
+        self._tasks.append(asyncio.create_task(self._consume_fills(fill_sub)))
+        self._tasks.append(asyncio.create_task(self._consume_positions(pos_sub)))
+        self._running = True
+        self.logger.info("Strategy analytics service started")
+
+    async def stop(self) -> None:
+        """Stop analytics consumers and unsubscribe."""
+        self._running = False
+        for task in self._tasks:
+            task.cancel()
+            try:
+                await task
+            except asyncio.CancelledError:
+                pass
+        self._tasks.clear()
+        for sub in self._subscriptions:
+            sub.close()
+        self._subscriptions.clear()
+        self.logger.info("Strategy analytics service stopped")
+
+    async def _consume_fills(self, subscription: Subscription) -> None:
+        try:
+            async for _, payload in subscription:
+                if not self._running:
+                    break
+                self._handle_fill(payload)
+        except asyncio.CancelledError:
+            pass
+        except Exception as e:
+            self.logger.error(f"Fill consumer error: {e}")
+
+    async def _consume_positions(self, subscription: Subscription) -> None:
+        try:
+            async for _, payload in subscription:
+                if not self._running:
+                    break
+                self._handle_position(payload)
+        except asyncio.CancelledError:
+            pass
+        except Exception as e:
+            self.logger.error(f"Position consumer error: {e}")
+
+    def _get_strategy_metrics(self, strategy_id: str) -> Dict[str, Any]:
+        return self._metrics.setdefault(
+            strategy_id, {"trades_executed": 0, "realized_pnl": 0.0, "position": 0}
+        )
+
+    def _handle_fill(self, payload: Dict[str, Any]) -> None:
+        strategy_id = payload.get("strategy_id")
+        custom_tag = payload.get("custom_tag")
+        if not strategy_id and custom_tag:
+            strategy_id = str(custom_tag).split("_")[0]
+        if not strategy_id:
+            return
+        metrics = self._get_strategy_metrics(strategy_id)
+        metrics["trades_executed"] += 1
+        pnl = payload.get("pnl")
+        if pnl is not None:
+            metrics["realized_pnl"] += float(pnl)
+
+    def _handle_position(self, payload: Dict[str, Any]) -> None:
+        strategy_id = payload.get("strategy_id")
+        if not strategy_id:
+            return
+        metrics = self._get_strategy_metrics(strategy_id)
+        position = payload.get("position")
+        if position is not None:
+            metrics["position"] = int(position)
+        pnl = payload.get("pnl")
+        if pnl is not None:
+            metrics["realized_pnl"] = float(pnl)
+
+    def get_metrics(self) -> Dict[str, Dict[str, Any]]:
+        """Return metrics for all strategies."""
+        return {sid: data.copy() for sid, data in self._metrics.items()}

--- a/topstepx_backend/orchestrator.py
+++ b/topstepx_backend/orchestrator.py
@@ -33,6 +33,7 @@ from topstepx_backend.strategy.registry import StrategyRegistry
 from topstepx_backend.networking.subscription_manager import SubscriptionManager
 from topstepx_backend.services.risk_manager import RiskManager
 from topstepx_backend.api.server import APIServer
+from topstepx_backend.analytics.strategy_analytics import StrategyAnalytics
 
 
 class SystemHealth:
@@ -128,6 +129,7 @@ class TopstepXOrchestrator:
         # Trading services
         self.order_service: Optional[OrderService] = None
         self.risk_manager: Optional[RiskManager] = None
+        self.strategy_analytics: Optional[StrategyAnalytics] = None
         self.strategy_runner: Optional[StrategyRunner] = None
         self.api_server: Optional[APIServer] = None
 
@@ -204,6 +206,7 @@ class TopstepXOrchestrator:
             self.order_service = OrderService(
                 self.event_bus, self.auth_manager, self.config, self.rate_limiter
             )
+            self.strategy_analytics = StrategyAnalytics(self.event_bus)
             registry = StrategyRegistry()
             self.strategy_runner = StrategyRunner(
                 self.event_bus,
@@ -230,6 +233,7 @@ class TopstepXOrchestrator:
                 self.user_hub,
                 self.risk_manager,
                 self.order_service,
+                self.strategy_analytics,
                 self.strategy_runner,
                 self.api_server,
             ]
@@ -481,6 +485,9 @@ class TopstepXOrchestrator:
         # Add persistence service metrics
         if self.persistence:
             status["persistence"] = self.persistence.get_metrics()
+
+        if self.strategy_analytics:
+            status["strategy_analytics"] = self.strategy_analytics.get_metrics()
 
         return status
 


### PR DESCRIPTION
## Summary
- implement StrategyAnalytics service to aggregate per-strategy metrics from fill and position events
- wire StrategyAnalytics into orchestrator startup and system status reporting
- add unit test for StrategyAnalytics metrics

## Testing
- `pytest` *(fails: ImportError: cannot import name 'APIRouter' from 'fastapi')*
- `pytest tests/services/test_strategy_analytics.py`


------
https://chatgpt.com/codex/tasks/task_e_68ae8ea6f8b48330abb670b7fe203133