### PR TITLE
Add /metrics endpoint for strategy stats

### DIFF
--- a/tests/test_api_server.py
+++ b/tests/test_api_server.py
@@ -12,6 +12,15 @@ class DummyAuth:
         return "token"
 
 
+class DummyStrategyRunner:
+    def __init__(self) -> None:
+        self.stats_called = False
+
+    def get_strategy_stats(self):
+        self.stats_called = True
+        return {"running": False}
+
+
 class DummyOrchestrator:
     def __init__(self) -> None:
         self.event_bus = EventBus()
@@ -20,6 +29,7 @@ class DummyOrchestrator:
         self.submit_payload = None
         self.add_payload = None
         self.remove_id = None
+        self.strategy_runner = DummyStrategyRunner()
 
     def get_system_status(self):
         self.status_called = True
@@ -74,6 +84,12 @@ def test_rest_endpoints():
     data = StrategyResponse(**resp.json())
     assert data.status == "removed"
     assert orch.remove_id == "abc"
+
+    # metrics
+    resp = client.get("/metrics")
+    assert resp.status_code == 200
+    assert resp.json() == {"running": False}
+    assert orch.strategy_runner.stats_called
 
 
 def test_websocket_gateway():

--- a/topstepx_backend/api/server.py
+++ b/topstepx_backend/api/server.py
@@ -96,6 +96,16 @@ class APIServer(Service):
         async def status() -> StatusResponse:
             return StatusResponse(**self.orchestrator.get_system_status())
 
+        @self.app.get("/metrics")
+        async def metrics() -> Dict[str, Any]:
+            """Return strategy metrics from the orchestrator."""
+            runner = getattr(self.orchestrator, "strategy_runner", None)
+            if runner is None:
+                raise HTTPException(
+                    status_code=503, detail="Strategy runner not initialized"
+                )
+            return runner.get_strategy_stats()
+
         @self.app.post("/auth/token", response_model=TokenResponse)
         async def auth_token(request: TokenRequest) -> TokenResponse:
             try:


### PR DESCRIPTION
## Summary
- expose `GET /metrics` on API server to return strategy runner statistics
- test metrics endpoint with dummy strategy runner

## Testing
- `pytest -q` *(fails: ImportError: cannot import name 'APIRouter' from '<unknown module name>', FastAPI missing)*
- `pytest tests/test_event_bus.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68ae8ea9f0108330a6575f948f872ecf