### PR TITLE
chore: ignore node modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 .env
+
+node_modules/


### PR DESCRIPTION
## Summary
- stop tracking node_modules by adding it to .gitignore

## Testing
- `python -m compileall topstepx_backend`
- `pytest tests/test_event_bus.py`
- `pytest` *(fails: cannot import FastAPI due to missing dependency; attempted `pip install fastapi` but network blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68af50d209708330adfe772e0450233e