### PR TITLE
Initialize ContractService in orchestrator for symbol resolution

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -26,10 +26,29 @@ aiohttp_stub = types.SimpleNamespace(
 sys.modules.setdefault("aiohttp", aiohttp_stub)
 sys.modules.setdefault("dotenv", types.SimpleNamespace(load_dotenv=lambda *a, **k: None))
 sys.modules.setdefault("yaml", types.SimpleNamespace(safe_load=lambda *a, **k: {}))
-sys.modules.setdefault("pydantic", types.SimpleNamespace(BaseSettings=object, Field=lambda *a, **k: None))
+# Minimal Pydantic BaseModel stub
+class _BaseModel:
+    def __init__(self, **data):
+        for k, v in data.items():
+            setattr(self, k, v)
+
+    def dict(self):  # pragma: no cover - simple stub
+        return dict(self.__dict__)
+
+
+sys.modules.setdefault(
+    "pydantic",
+    types.SimpleNamespace(
+        BaseSettings=object, BaseModel=_BaseModel, Field=lambda *a, **k: None
+    ),
+)
 pysignalr_client = types.SimpleNamespace(SignalRClient=object)
 sys.modules.setdefault("pysignalr", types.SimpleNamespace(client=pysignalr_client))
 sys.modules.setdefault("pysignalr.client", pysignalr_client)
+sys.modules.setdefault(
+    "uvicorn",
+    types.SimpleNamespace(Config=object, Server=object),
+)
 
 # Minimal FastAPI stub
 import re, inspect, asyncio

--- a/topstepx_backend/orchestrator.py
+++ b/topstepx_backend/orchestrator.py
@@ -28,6 +28,7 @@ from topstepx_backend.services.persistence import PersistenceService
 from topstepx_backend.services.order_service import OrderService
 from topstepx_backend.services.series_cache_service import SeriesCacheService
 from topstepx_backend.services.market_subscription_service import MarketSubscriptionService
+from topstepx_backend.services.contract_service import ContractService
 from topstepx_backend.strategy.runner import StrategyRunner
 from topstepx_backend.strategy.registry import StrategyRegistry
 from topstepx_backend.networking.subscription_manager import SubscriptionManager
@@ -124,6 +125,7 @@ class TopstepXOrchestrator:
         self.polling_bar_service: Optional[PollingBarService] = None
         self.historical_fetcher: Optional[HistoricalFetcher] = None
         self.timeframe_aggregator: Optional[TimeframeAggregator] = None
+        self.contract_service: Optional[ContractService] = None
         # Coordinates dynamic market data subscriptions
         self.market_subscription_service: Optional[MarketSubscriptionService] = None
         self.series_cache_service: Optional[SeriesCacheService] = None
@@ -197,11 +199,14 @@ class TopstepXOrchestrator:
             self.subscription_manager = SubscriptionManager(self.rate_limiter)
 
             # --- Data sourcing and transformation services ---
+            self.contract_service = ContractService(
+                self.config, self.auth_manager, self.rate_limiter
+            )
             self.timeframe_aggregator = TimeframeAggregator(
                 self.config, self.event_bus
             )
             self.market_subscription_service = MarketSubscriptionService(
-                self.config, self.event_bus
+                self.config, self.event_bus, self.contract_service
             )
             self.historical_fetcher = HistoricalFetcher(
                 self.config, self.auth_manager, self.rate_limiter, self.event_bus
@@ -246,6 +251,7 @@ class TopstepXOrchestrator:
                 self.event_bus,
                 self.clock,
                 self.persistence,
+                self.contract_service,
                 self.timeframe_aggregator,
                 self.market_subscription_service,
                 self.historical_fetcher,


### PR DESCRIPTION
## Summary
- instantiate ContractService during service initialization and pass to MarketSubscriptionService
- track ContractService lifecycle alongside other services
- extend test stubs for BaseModel and uvicorn to run API tests

## Testing
- `pytest tests/auth -q`
- `pytest tests/services -q`
- `pytest tests/test_event_bus.py -q`
- `pytest tests/integration -q`
- `pytest tests/test_api_server.py -q` *(requires manual interrupt to exit)*

------
https://chatgpt.com/codex/tasks/task_e_68af61658f48833081b4d3fedb046ef4