### PR TITLE
Add contract filtering and API query support

### DIFF
--- a/tests/services/test_contract_service_filters.py
+++ b/tests/services/test_contract_service_filters.py
@@ -1,0 +1,62 @@
+import pytest
+
+from topstepx_backend.services.contract_service import ContractService, Contract
+from topstepx_backend.config.settings import TopstepConfig
+from topstepx_backend.networking.rate_limiter import RateLimiter
+
+
+class DummyAuth:
+    def get_token(self) -> str:
+        return "token"
+
+
+def create_service() -> ContractService:
+    config = TopstepConfig(
+        username="u",
+        api_key="k" * 16,
+        account_id=1,
+        account_name="a",
+        projectx_base_url="http://example.com",
+        projectx_user_hub_url="http://example.com/user",
+        projectx_market_hub_url="http://example.com/market",
+        database_path=":memory:",
+        log_level="INFO",
+        environment="test",
+    )
+    return ContractService(config, DummyAuth(), RateLimiter())
+
+
+@pytest.mark.asyncio
+async def test_filter_contracts_by_symbol_and_sector():
+    service = create_service()
+    c1 = Contract(
+        id="1",
+        name="E-mini S&P",
+        symbol="ESU24",
+        contract_type="F",
+        market="US",
+        is_active=True,
+        tick_size=0.25,
+        point_value=12.5,
+        currency="USD",
+        sector="EP",
+    )
+    c2 = Contract(
+        id="2",
+        name="Euro FX",
+        symbol="6EU24",
+        contract_type="F",
+        market="US",
+        is_active=True,
+        tick_size=0.0001,
+        point_value=125000.0,
+        currency="USD",
+        sector="EU",
+    )
+    service._contracts = {c1.id: c1, c2.id: c2}
+
+    result = await service.filter_contracts(symbol_prefix="ES")
+    assert [c.id for c in result] == ["1"]
+
+    result = await service.filter_contracts(sector="EU")
+    assert [c.id for c in result] == ["2"]

--- a/tests/test_api_server.py
+++ b/tests/test_api_server.py
@@ -48,6 +48,8 @@ class DummyOrchestrator:
         self.health_called = False
         self.logs_called = False
         self.config_called = False
+        self.symbol_filter = None
+        self.sector_filter = None
 
     def get_system_status(self):
         self.status_called = True
@@ -63,8 +65,10 @@ class DummyOrchestrator:
         self.remove_id = sid
 
     # Market data
-    def get_contracts(self):
+    def get_contracts(self, symbol: str | None = None, sector: str | None = None):
         self.contracts_called = True
+        self.symbol_filter = symbol
+        self.sector_filter = sector
         return ["ES"]
 
     def get_market_data(self, contract):
@@ -183,6 +187,11 @@ def test_rest_endpoints():
     assert resp.status_code == 200
     assert resp.json() == ["ES"]
     assert orch.contracts_called
+
+    resp = client.get("/contracts?symbol=ES&sector=EP")
+    assert resp.status_code == 200
+    assert orch.symbol_filter == "ES"
+    assert orch.sector_filter == "EP"
 
     resp = client.get("/market-data/ES")
     assert resp.json()["contract"] == "ES"

--- a/topstepx_backend/api/routes/market_data.py
+++ b/topstepx_backend/api/routes/market_data.py
@@ -6,17 +6,26 @@ from fastapi import APIRouter, Request
 router = APIRouter()
 
 
-def _call(orchestrator: Any, name: str, *args, default: Any = None) -> Any:
+def _call(
+    orchestrator: Any, name: str, *args, default: Any = None, **kwargs
+) -> Any:
     func = getattr(orchestrator, name, None)
     if func is None:
         return default
-    return func(*args)
+    return func(*args, **kwargs)
 
 
 @router.get("/contracts")
-async def get_contracts(request: Request) -> List[Any]:
+async def get_contracts(
+    request: Request, symbol: str | None = None, sector: str | None = None
+) -> List[Any]:
     orchestrator = request.app.state.orchestrator
-    result = _call(orchestrator, "get_contracts", default=[])
+    kwargs = {}
+    if symbol is not None:
+        kwargs["symbol"] = symbol
+    if sector is not None:
+        kwargs["sector"] = sector
+    result = _call(orchestrator, "get_contracts", default=[], **kwargs)
     if inspect.isawaitable(result):
         result = await result
     return result

--- a/topstepx_backend/services/contract_service.py
+++ b/topstepx_backend/services/contract_service.py
@@ -262,6 +262,41 @@ class ContractService:
 
         return None
 
+    async def filter_contracts(
+        self,
+        symbol_prefix: Optional[str] = None,
+        sector: Optional[str] = None,
+        active_only: bool = False,
+    ) -> List[Contract]:
+        """Filter cached contracts by symbol prefix and/or sector.
+
+        Args:
+            symbol_prefix: Return contracts whose symbol starts with this prefix.
+            sector: Limit results to contracts belonging to this sector.
+            active_only: Only include active contracts when True.
+        """
+        if not self._contracts:
+            await self.discover_contracts()
+
+        results: List[Contract] = list(self._contracts.values())
+
+        if symbol_prefix:
+            prefix = symbol_prefix.lower()
+            results = [c for c in results if c.symbol.lower().startswith(prefix)]
+
+        if sector:
+            sector_lower = sector.lower()
+            results = [
+                c
+                for c in results
+                if c.sector and c.sector.lower() == sector_lower
+            ]
+
+        if active_only:
+            results = [c for c in results if c.is_active]
+
+        return results
+
     async def search_contracts_api(
         self, query: str, live: bool = False
     ) -> List[Contract]:


### PR DESCRIPTION
## Summary
- add flexible contract filters to `ContractService`
- support `symbol` and `sector` query parameters on `/contracts`
- test passing of query params and filtering logic

## Testing
- `pytest tests/test_api_server.py::test_rest_endpoints -q` *(fails: ImportError: cannot import name 'BaseModel' from '<unknown module name>' (pydantic missing))*
- `pytest tests/services/test_contract_service_filters.py -q` *(fails: async def functions are not natively supported)*

------
https://chatgpt.com/codex/tasks/task_e_68af6165772c8330b2ab11543f56ac47